### PR TITLE
Add Lava Slide self-target mode

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 1.56:
 * Add support for taking over /AI
-* Fix issue with pauses bugging up predictive move. 
+* Added Lava Slide self-targeting mode (LavaSlideMode = 3)
+* Fix issue with pauses bugging up predictive move.
 * Corrected issue that could cause rescuer to get distracted .
 * Corrected issue where state of skill use count could be lost.
 * Corrected issue with Tanking tactic.

--- a/GUI/AzzyAIConfig/HomConf.cs
+++ b/GUI/AzzyAIConfig/HomConf.cs
@@ -147,14 +147,15 @@ namespace AzzyAIConfig
         Disabled = 0,
         Enabled = 1
     }
-	enum LavaSlideModeOptions : sbyte
-	{
-		Attack = 0,
-		Idle = 1,
-		Chase = -1,
-		Idle_Low = -2,
-        Berserk = 2
-	}
+        enum LavaSlideModeOptions : sbyte
+        {
+                Attack = 0,
+                Idle = 1,
+                Chase = -1,
+                Idle_Low = -2,
+        Berserk = 2,
+        Self = 3
+        }
 	enum PoisonMistModeOptions : sbyte
 	{
 		Attack = 0,
@@ -2712,7 +2713,8 @@ LavaSlideModeOptions _LavaSlideMode = LavaSlideModeOptions.Attack;
 	[Category("Autobuff Options"),
 	Description(
         "If set to anything except 'attack', Lava Slide will be cast at the owner's feet - This improves exp/hr while AFKing on maps like OD2, and also makes it easier for others on the map. This is handled like a buff skill; 'Idle' is the recommended setting." +
-		"If set to 'attack', Lava Slide will be used as an AoE attack (controlled by the AutoMobMode AutoMobCount settings). This is recommended only for non-AFK leveling. " +
+                "If set to 'attack', Lava Slide will be used as an AoE attack (controlled by the AutoMobMode AutoMobCount settings). This is recommended only for non-AFK leveling. " +
+        "Use 'Self' to cast the skill centered on Dieter instead of the owner." +
         "Note that the AI cannot detect when Lava Slide is canceled, so either way, it will assume it lasts 7.5 seconds, and may try to recast after that"
 		),
 	DefaultValue(LavaSlideModeOptions.Attack)]

--- a/README.md
+++ b/README.md
@@ -10,3 +10,6 @@ I no longer play RO, and do not have time to take it up or maintain this AI exce
 * USER_AI contains AzzyAI
 * scripts contains scripts used to prepare releases of AzzyAI
 * AzzyAIConfig contains the source code for the config tool
+
+### New Option
+* LavaSlideMode now supports "Self" to cast at Dieter instead of the owner.

--- a/USER_AI/AI_main.lua
+++ b/USER_AI/AI_main.lua
@@ -2479,7 +2479,7 @@ function DoAutoBuffs(buffmode)
 	if SightTimeout ~=-1 then
 		TraceAI("tick:"..GetTick().."SightTimeout"..SightTimeout)
 		if (GetTick() > SightTimeout) then
-			local skill,level,opt = GetSightOrAoE(MyID)
+                        local skill,level,opt,selftgt = GetSightOrAoE(MyID)
 			if (skill <= 0) then
 				SightTimeout = -1
 			elseif level==0 or opt~=buffmode then
@@ -2493,7 +2493,11 @@ function DoAutoBuffs(buffmode)
 					else
 						MyPState = MyState
 						MyState = PROVOKE_ST
-						MyPEnemy = GetV(V_OWNER,MyID)
+                                                if selftgt==1 then
+                                                        MyPEnemy = MyID
+                                                else
+                                                        MyPEnemy = GetV(V_OWNER,MyID)
+                                                end
 						MyPSkill = skill
 						MyPSkillLevel = level
 						MyPMode = 7

--- a/USER_AI/AzzyUtil.lua
+++ b/USER_AI/AzzyUtil.lua
@@ -2135,6 +2135,7 @@ function	GetSOffensiveSkill(myid)
 	local level = 0
 	local skill = 0
 	local skillopt = 0
+        local selftarget = 0
 	if (IsHomun(myid)==1) then
 		htype=GetV(V_HOMUNTYPE,myid)
 		if (htype==BAYERI and UseBayeriAngriffModus~=0) then
@@ -2146,7 +2147,7 @@ function	GetSOffensiveSkill(myid)
 			level = 5
 			skillopt=UseDieterMagmaFlow
 		end
-		return skill,level,skillopt
+		return skill,level,skillopt,selftarget
 	else
 		level=SkillList[MercType][MER_BLESSING]
 		if level~=nil then
@@ -2173,7 +2174,7 @@ function	GetSDefensiveSkill(myid)
 			level = 5
 			skillopt=UseDieterGraniticArmor
 		end
-		return skill,level,skillopt
+		return skill,level,skillopt,selftarget
 	else
 		level=SkillList[MercType][MER_KYRIE]
 		if level~=nil then
@@ -2190,6 +2191,7 @@ function	GetSOwnerBuffSkill(myid)
 	local level = 0
 	local skill = 0
 	local skillopt = 0
+        local selftarget = 0
 	if (IsHomun(myid)==1) then
 		htype=GetV(V_HOMUNTYPE,myid)
 		if (htype==EIRA and UseEiraOveredBoost~=0) then
@@ -2205,7 +2207,7 @@ function	GetSOwnerBuffSkill(myid)
 			end
 			skillopt=UseDieterPyroclastic
 		end
-		return skill,level,skillopt
+		return skill,level,skillopt,selftarget
 	else
 		level=SkillList[MercType][MER_INCAGI]
 		if level~=nil then
@@ -2222,12 +2224,16 @@ function GetSightOrAoE(myid)
 	local level = 0
 	local skill = 0
 	local skillopt = 0
+        local selftarget = 0
 	if (IsHomun(myid)==1) then
 		htype=GetV(V_HOMUNTYPE,myid)
 		if	(htype==DIETER and UseDieterLavaSlide==1 and LavaSlideMode~=0) then
 			skill=MH_LAVA_SLIDE
 			level = 10
 			skillopt=LavaSlideMode
+                        if LavaSlideMode==3 then
+                                selftarget=1
+                        end
 		elseif (htype==SERA and PoisonMistMode~=0 and UseSeraPoisonMist==1) then
 			skill=MH_POISON_MIST
 			level = 5
@@ -2246,7 +2252,7 @@ function GetSightOrAoE(myid)
 			skill=skill
 		end
 	end
-	return skill,level,skillopt
+	return skill,level,skillopt,selftarget
 end
 function	GetGuardSkill(myid)
 	local level = 0
@@ -2297,6 +2303,7 @@ function	GetOffensiveOwnerSkill(myid)
 	local level = 0
 	local skill = 0
 	local skillopt = 0
+        local selftarget = 0
 	if (IsHomun(myid)==1) then
 		return 0,0,0
 	else
@@ -2313,6 +2320,7 @@ function	GetDefensiveOwnerSkill(myid)
 	local level = 0
 	local skill = 0
 	local skillopt = 0
+        local selftarget = 0
 	if (IsHomun(myid)==1) then
 		if GetV(V_HOMUNTYPE,MyID)==SERA and UseSeraPainkiller~=0 then
 			level=5
@@ -2334,6 +2342,7 @@ function	GetOtherOwnerSkill(myid)
 	local level = 0
 	local skill = 0
 	local skillopt = 0
+        local selftarget = 0
 	if (IsHomun(myid)==1) then
 		return 0,0,0
 	else


### PR DESCRIPTION
## Summary
- add new `Self` option to `LavaSlideModeOptions`
- support self-target indicator in `GetSightOrAoE`
- cast Lava Slide on Dieter when `Self` selected
- document new option

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68505c2ee69c832187ab8d81c0164aba